### PR TITLE
Pin apispec beta

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,9 @@ sudo: false
 # python settings
 language: python
 python:
+  - "2.7"
   - "3.5"
   - "3.6"
-  - "3.7"
 
 # install packages
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ sudo: false
 # python settings
 language: python
 python:
-  - "2.7"
   - "3.5"
   - "3.6"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ language: python
 python:
   - "3.5"
   - "3.6"
+  - "3.7"
 
 # install packages
 install:
@@ -16,7 +17,7 @@ install:
 
 # run test
 script:
-  - python -m pytest --cov
+  - python -m pytest --cov=falcon_apispec
 
 after_success:
   - codecov

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-git+git://github.com/marshmallow-code/apispec.git#master
+apispec.git>=1.0.0b1
 falcon
 pytest
 pytest-cov

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+PyYAML>=3.10
 apispec>=1.0.0b1
 falcon
 pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-apispec.git>=1.0.0b1
+apispec>=1.0.0b1
 falcon
 pytest
 pytest-cov


### PR DESCRIPTION
This plugin is built on top of apispec's new plugin interface. Pinning dependency to `apispec==1.0.0b1`.