### PR TITLE
Pin to apispec 1.0b1

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 pip install falcon-apispec
 ```
 
-Requires `apispec v1.0` (works with beta).
+Requires `apispec v1.0` (works with beta). You might need to check the latest version of the [docs](https://apispec.readthedocs.io/en/latest/) for exact usage. I won't be tracking changes until `apispec` hits 1.0rc1.
 
 ## Example Application
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 PyYAML>=3.10
-apispec>=1.0.0b1
+apispec==1.0.0b1
 falcon
 flake8
 pytest


### PR DESCRIPTION
Builds keep breaking as the apispec API is in flux. Pin requirements to first beta and have a link to the latest version of the apispec docs.