### PR TITLE
Update to APISpec 1.3.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,8 @@ spec = APISpec(
 # Register entities and paths
 spec.definition('Category', schema=CategorySchema)
 spec.definition('Pet', schema=PetSchema)
-# pass created resource into `add_path` for APISpec
-spec.add_path(resource=random_pet_resource)
+# pass created resource into `path` for APISpec
+spec.path(resource=random_pet_resource)
 ```
 
 ### Generated OpenAPI Spec

--- a/README.md
+++ b/README.md
@@ -67,8 +67,8 @@ spec = APISpec(
 )
 
 # Register entities and paths
-spec.definition('Category', schema=CategorySchema)
-spec.definition('Pet', schema=PetSchema)
+spec.components.schema('Category', schema=CategorySchema)
+spec.components.schema('Pet', schema=PetSchema)
 # pass created resource into `path` for APISpec
 spec.path(resource=random_pet_resource)
 ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 PyYAML>=3.10
-apispec==1.3.3
+apispec<1.4
 falcon
 flake8
 pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 PyYAML>=3.10
-apispec==1.0.0b1
+apispec==1.3.3
 falcon
 flake8
 pytest

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(
 
     install_requires=[
         "PyYAML>=3.10",
-        "apispec>=1.0.0b1",
+        "apispec<1.4",
         "falcon",
     ],
     packages=find_packages(exclude=["tests", ]),

--- a/tests/falcon_test.py
+++ b/tests/falcon_test.py
@@ -11,6 +11,7 @@ def spec_factory():
         return APISpec(
             title="Swagger Petstore",
             version="1.0.0",
+            openapi_version="3.0.2",
             description="This is a sample Petstore server.  You can find out more "
             'about Swagger at <a href="http://swagger.wordnik.com">http://swagger.wordnik.com</a> '
             "or on irc.freenode.net, #swagger.  For this sample, you can use the api "
@@ -42,12 +43,12 @@ class TestPathHelpers:
 
         expected = {
             "description": "get a greeting",
-            "responses": {200: {"description": "said hi"}},
+            "responses": {'200': {"description": "said hi"}},
         }
         hello_resource = HelloResource()
         app.add_route("/hi", hello_resource)
         spec = spec_factory(app)
-        spec.add_path(resource=hello_resource)
+        spec.path(resource=hello_resource)
 
         assert spec._paths["/hi"]["get"] == expected
 
@@ -65,16 +66,16 @@ class TestPathHelpers:
 
         expected = {
             "description": "get a greeting",
-            "responses": {201: {"description": "posted something"}},
+            "responses": {'201': {"description": "posted something"}},
         }
         hello_resource = HelloResource()
         app.add_route("/hi", hello_resource)
         spec = spec_factory(app)
-        spec.add_path(resource=hello_resource)
+        spec.path(resource=hello_resource)
 
         assert spec._paths["/hi"]["post"] == expected
 
-    def test_resource_with_metadata(selfself, app, spec_factory):
+    def test_resource_with_metadata(self, app, spec_factory):
         class HelloResource:
             """Greeting API.
             ---
@@ -84,6 +85,6 @@ class TestPathHelpers:
         hello_resource = HelloResource()
         app.add_route("/hi", hello_resource)
         spec = spec_factory(app)
-        spec.add_path(resource=hello_resource)
+        spec.path(resource=hello_resource)
 
         assert spec._paths["/hi"]["x-extension"] == "global metadata"

--- a/tests/falcon_test.py
+++ b/tests/falcon_test.py
@@ -43,7 +43,7 @@ class TestPathHelpers:
 
         expected = {
             "description": "get a greeting",
-            "responses": {'200': {"description": "said hi"}},
+            "responses": {"200": {"description": "said hi"}},
         }
         hello_resource = HelloResource()
         app.add_route("/hi", hello_resource)
@@ -66,7 +66,7 @@ class TestPathHelpers:
 
         expected = {
             "description": "get a greeting",
-            "responses": {'201': {"description": "posted something"}},
+            "responses": {"201": {"description": "posted something"}},
         }
         hello_resource = HelloResource()
         app.add_route("/hi", hello_resource)


### PR DESCRIPTION
The only breaking change was .add_path() which was renamed to .path() and the response codes are now strings.

Also slipped in a little typo fix in the arguments for `test_resource_with_metadata` and updated `spec.definition` to the new call in the README.

Related to this bug report: https://github.com/alysivji/falcon-apispec/issues/9