### PR TITLE
Fix example code in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,12 +39,11 @@ class RandomPetResource:
     def on_get(self, req, resp):
         """A cute furry animal endpoint.
         ---
-        get:
-            description: Get a random pet
-            responses:
-                200:
-                    description: A pet to be returned
-                    schema: PetSchema
+        description: Get a random pet
+        responses:
+            200:
+                description: A pet to be returned
+                schema: PetSchema
         """
         pet = get_random_pet()  # returns JSON
         resp.media = pet


### PR DESCRIPTION
I was trying out the example code in the README, and I noticed that the swagger file was double generating a `get:` key when parsing the docstring from the `on_get` method, ie:

```yaml
...
  get:
    get:
      description: Get a random pet
...
```

removing the `get:` in the docstring seems to cause the swagger file to be generated properly.