### PR TITLE
create MANIFEST.in to include license file in source distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include LICENSE


### PR DESCRIPTION
This adds a `MANIFEST.in` file so that the license file is included in the source distribution as required by the MIT license. 