### PR TITLE
Add base_path param for subtracting redundant basepath in path output

### DIFF
--- a/falcon_apispec/falcon_plugin.py
+++ b/falcon_apispec/falcon_plugin.py
@@ -1,5 +1,5 @@
 import copy
-
+import re
 from apispec import BasePlugin, yaml_utils
 from apispec.exceptions import APISpecError
 import falcon
@@ -37,7 +37,8 @@ class FalconPlugin(BasePlugin):
         path = resource_uri_mapping[resource]
 
         if base_path is not None:
-            path = path.replace(base_path, "")
+            base_path = '/' + base_path.strip('/')
+            path = re.sub(base_path, "", path, 1)
 
         for method in falcon.constants.HTTP_METHODS:
             http_verb = method.lower()

--- a/falcon_apispec/falcon_plugin.py
+++ b/falcon_apispec/falcon_plugin.py
@@ -26,8 +26,6 @@ class FalconPlugin(BasePlugin):
 
     def path_helper(self, operations, resource, base_path=None, **kwargs):
         """Path helper that allows passing a Falcon resource instance."""
-        # NOTE(xakiy): add base_path param for subtracting redundant basepath
-        #              in path output
         resource_uri_mapping = self._generate_resource_uri_mapping(self._app)
 
         if resource not in resource_uri_mapping:
@@ -37,6 +35,8 @@ class FalconPlugin(BasePlugin):
         path = resource_uri_mapping[resource]
 
         if base_path is not None:
+            # make sure base_path accept either with or without leading slash
+            # swagger 2 usually come with leading slash but not in openapi 3.x.x
             base_path = '/' + base_path.strip('/')
             path = re.sub(base_path, "", path, 1)
 

--- a/tests/falcon_test.py
+++ b/tests/falcon_test.py
@@ -1,22 +1,51 @@
 import pytest
-
+import yaml
 import falcon
 from apispec import APISpec
 from falcon_apispec import FalconPlugin
 
 
 @pytest.fixture()
-def spec_factory():
+def settings():
+    OPENAPI_SPEC = """
+    openapi: 3.0.2
+    info:
+      title: Swagger Petstore
+      version: 1.0.0
+      description: 'This is a sample server Petstore server. You can find out more about Swagger
+        at [https://swagger.io](https://swagger.io) or on [irc.freenode.net, #swagger](https://swagger.io/irc/).
+        For this sample, you can use the api key `special-key` to test the authorization filters.'
+    servers:
+    - url: http://localhost:{port}/{basePath}
+      description: The development API server
+      variables:
+        port:
+          enum:
+          - '3000'
+          - '8888'
+          default: '3000'
+        basePath:
+          default: v1
+    """
+    return yaml.safe_load(OPENAPI_SPEC)
+
+
+@pytest.fixture()
+def spec_factory(settings):
     def _spec(app):
+        # retrieve  title, version, and openapi version
+        title = settings["info"].pop("title")
+        spec_version = settings["info"].pop("version")
+        openapi_version = settings.pop("openapi")
+        description = settings["info"].pop("description")
+
         return APISpec(
-            title="Swagger Petstore",
-            version="1.0.0",
-            openapi_version="3.0.2",
-            description="This is a sample Petstore server.  You can find out more "
-            'about Swagger at <a href="http://swagger.wordnik.com">http://swagger.wordnik.com</a> '
-            "or on irc.freenode.net, #swagger.  For this sample, you can use the api "
-            'key "special-key" to test the authorization filters',
+            title=title,
+            version=spec_version,
+            openapi_version=openapi_version,
+            description=description,
             plugins=[FalconPlugin(app)],
+            **settings
         )
 
     return _spec
@@ -88,3 +117,31 @@ class TestPathHelpers:
         spec.path(resource=hello_resource)
 
         assert spec._paths["/hi"]["x-extension"] == "global metadata"
+
+    def test_unredundant_basepath_resource(self, app, spec_factory, settings):
+        class HelloResource:
+            def on_get(self, req, resp):
+                """A greeting endpoint.
+                ---
+                description: get a greeting
+                responses:
+                    200:
+                        description: said hi
+                """
+                return "dummy"
+
+        expected = {
+            "description": "get a greeting",
+            "responses": {"200": {"description": "said hi"}},
+        }
+        full_path = "/v1/foo/v1"
+        path_expected = "/foo/v1"
+        hello_resource = HelloResource()
+        app.add_route(full_path, hello_resource)
+        spec = spec_factory(app)
+        base_path = settings["servers"][0]["variables"]["basePath"].get("default")
+        # in swagger 2 this is simply 'basePath: /v1'
+        spec.path(resource=hello_resource, base_path=base_path)
+
+        assert spec._paths.get(path_expected) is not None
+        assert spec._paths[path_expected]["get"] == expected

--- a/tests/falcon_test.py
+++ b/tests/falcon_test.py
@@ -12,9 +12,11 @@ def settings():
     info:
       title: Swagger Petstore
       version: 1.0.0
-      description: 'This is a sample server Petstore server. You can find out more about Swagger
-        at [https://swagger.io](https://swagger.io) or on [irc.freenode.net, #swagger](https://swagger.io/irc/).
-        For this sample, you can use the api key `special-key` to test the authorization filters.'
+      description: 'This is a sample server Petstore server. You can find out
+        more about Swagger at [https://swagger.io](https://swagger.io) or on
+        [irc.freenode.net, #swagger](https://swagger.io/irc/).
+        For this sample, you can use the api key `special-key` to test
+        the authorization filters.'
     servers:
     - url: http://localhost:{port}/{basePath}
       description: The development API server
@@ -139,7 +141,8 @@ class TestPathHelpers:
         hello_resource = HelloResource()
         app.add_route(full_path, hello_resource)
         spec = spec_factory(app)
-        base_path = settings["servers"][0]["variables"]["basePath"].get("default")
+        base_path = \
+            settings["servers"][0]["variables"]["basePath"].get("default")
         # in swagger 2 this is simply 'basePath: /v1'
         spec.path(resource=hello_resource, base_path=base_path)
 


### PR DESCRIPTION
Sometimes it looks annoying if you have redundant basepath across path is your API spec, so this patch remove that for you.