### PR TITLE
Add support for Falcon Resource suffixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,7 @@ venv.bak/
 .vscode
 .envrc
 todo.md
+
+# PYCharm
+.idea/
+

--- a/falcon_apispec/falcon_plugin.py
+++ b/falcon_apispec/falcon_plugin.py
@@ -2,7 +2,6 @@ import copy
 import re
 from apispec import BasePlugin, yaml_utils
 from apispec.exceptions import APISpecError
-import falcon
 
 
 class FalconPlugin(BasePlugin):

--- a/falcon_apispec/falcon_plugin.py
+++ b/falcon_apispec/falcon_plugin.py
@@ -20,7 +20,17 @@ class FalconPlugin(BasePlugin):
         for route in routes_to_check:
             uri = route.uri_template
             resource = route.resource
-            mapping[resource] = uri
+            mapping[resource] = {
+                "uri": uri,
+                "methods": {}
+            }
+
+            if route.method_map:
+                for method_name, method_handler in route.method_map.items():
+                    if method_handler.__dict__.get("__module__") == "falcon.responders":
+                        continue
+                    mapping[resource]["methods"][method_name.lower()] = method_handler
+
             routes_to_check.extend(route.children)
         return mapping
 
@@ -32,7 +42,7 @@ class FalconPlugin(BasePlugin):
             raise APISpecError("Could not find endpoint for resource {0}".format(resource))
 
         operations.update(yaml_utils.load_operations_from_docstring(resource.__doc__) or {})
-        path = resource_uri_mapping[resource]
+        path = resource_uri_mapping[resource]["uri"]
 
         if base_path is not None:
             # make sure base_path accept either with or without leading slash
@@ -40,11 +50,9 @@ class FalconPlugin(BasePlugin):
             base_path = '/' + base_path.strip('/')
             path = re.sub(base_path, "", path, 1)
 
-        for method in falcon.constants.HTTP_METHODS:
-            http_verb = method.lower()
-            method_name = "on_" + http_verb
-            if getattr(resource, method_name, None) is not None:
-                method = getattr(resource, method_name)
-                docstring_yaml = yaml_utils.load_yaml_from_docstring(method.__doc__)
-                operations[http_verb] = docstring_yaml or dict()
+        methods = resource_uri_mapping[resource]["methods"]
+
+        for method_name, method_handler in methods.items():
+            docstring_yaml = yaml_utils.load_yaml_from_docstring(method_handler.__doc__)
+            operations[method_name] = docstring_yaml or dict()
         return path

--- a/tests/falcon_test.py
+++ b/tests/falcon_test.py
@@ -137,3 +137,38 @@ class TestPathHelpers:
         spec.path(resource=hello_resource, base_path=base_path)
 
         assert spec._paths["/foo/v1"]["get"] == expected
+
+    def test_path_with_suffix(self, app, spec_factory):
+        class HelloResource:
+            def on_get_hello(self):
+                """A greeting endpoint.
+                ---
+                description: get a greeting
+                responses:
+                    200:
+                        description: said hi
+                """
+                return "dummy"
+
+            def on_get(self):
+                """An invalid method.
+                ---
+                description: this should not pass
+                responses:
+                    200:
+                        description: said hi
+                """
+                return "invalid"
+
+        expected = {
+            "description": "get a greeting",
+            "responses": {"200": {"description": "said hi"}},
+        }
+
+        hello_resource_with_suffix = HelloResource()
+        app.add_route("/hi", hello_resource_with_suffix, suffix="hello")
+
+        spec = spec_factory(app)
+        spec.path(resource=hello_resource_with_suffix)
+
+        assert spec._paths["/hi"]["get"] == expected

--- a/tests/falcon_test.py
+++ b/tests/falcon_test.py
@@ -1,7 +1,8 @@
-import pytest
-
 import falcon
+import pytest
 from apispec import APISpec
+from apispec.exceptions import APISpecError
+
 from falcon_apispec import FalconPlugin
 
 
@@ -172,3 +173,21 @@ class TestPathHelpers:
         spec.path(resource=hello_resource_with_suffix)
 
         assert spec._paths["/hi"]["get"] == expected
+
+    def test_resource_without_endpoint(self, app, spec_factory):
+        class HelloResource:
+            def on_get(self, req, resp):
+                """A greeting endpoint.
+                ---
+                description: get a greeting
+                responses:
+                    200:
+                        description: said hi
+                """
+                return "dummy"
+
+        hello_resource = HelloResource()
+        spec = spec_factory(app)
+
+        with pytest.raises(APISpecError):
+            spec.path(resource=hello_resource)


### PR DESCRIPTION
Closes #18.

Added support for the Falcon suffixes, using the Flacon's `router`.
There is no need to specify the `suffix` manually. The methods for the corresponding `Resource`, as is done for the `path`, is fetched automatically in `path_helper`.

Added tests for 100% coverage.