### PR TITLE
Support for Multi-Responders with the same method type

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,0 +1,21 @@
+[bumpversion]
+current_version = 0.4.0
+commit = True
+tag = False
+parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(?P<release>[a-z]+)?(?P<inc>\d+)?
+serialize = 
+	{major}.{minor}.{patch}{release}{inc}
+	{major}.{minor}.{patch}
+
+[bumpversion:part:release]
+optional_value = production
+first_value = alpha
+values = 
+	alpha
+	rc
+	production
+
+[bumpversion:file:falcon_apispec/version.py]
+search = __version__ = '{current_version}'
+replace = __version__ = '{new_version}'
+

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.4.0
+current_version = 0.5.0alpha0
 commit = True
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(?P<release>[a-z]+)?(?P<inc>\d+)?
@@ -16,6 +16,5 @@ values =
 	production
 
 [bumpversion:file:falcon_apispec/version.py]
-search = __version__ = '{current_version}'
-replace = __version__ = '{new_version}'
-
+search = __version__ = "{current_version}"
+replace = __version__ = "{new_version}"

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,22 @@
+[paths]
+source =
+   falcon_apispec
+   */site-packages
+
+[run]
+branch = true
+source =
+    falcon_apispec
+    tests
+parallel = true
+
+[report]
+show_missing = true
+precision = 2
+omit = *migrations*
+exclude_lines =
+    # Have to re-enable the standard pragma
+    pragma: no cover
+    # Don't complain if tests don't hit defensive assertion code:
+    raise NotImplementedError
+    pass

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ class SuffixedHelloResource:
     
 suffixed_resource = SuffixedHelloResource()
 app.add_route("/say", suffixed_resource)
-app.add_route("/say/hello", suffixed_resource, suffix="hello")
+app.add_route("/say/hi", suffixed_resource, suffix="hello")
 
 spec = spec_factory(app)
 spec.path(resource=suffixed_resource)  # registers on_get

--- a/README.md
+++ b/README.md
@@ -152,6 +152,46 @@ spec.to_yaml()
 # tags: []
 ```
 
+
+
+### Falcon Route Suffix Support
+
+Since Falcon 2.0, a single resource may contain several responders of the same HTTP type (e.g. 2 GETs) if a suffix is added at route creation.
+
+falcon-apispec >= 0.5 supports this through multiple APISpec path registration:
+
+```python
+class SuffixedHelloResource:
+    def on_get_hello(self):
+        """A greeting endpoint.
+            ---
+            description: get a greeting
+            responses:
+                200:
+                    description: said hi
+        """
+        return "dummy_hello"
+
+    def on_get(self):
+        """Base method.
+            ---
+            description: get something
+            responses:
+                200:
+                    description: said ???
+        """
+        return "dummy"
+
+    
+suffixed_resource = SuffixedHelloResource()
+app.add_route("/say", suffixed_resource)
+app.add_route("/say/hello", suffixed_resource, suffix="hello")
+
+spec = spec_factory(app)
+spec.path(resource=suffixed_resource)  # registers on_get
+spec.path(resource=suffixed_resource, suffix="hello")  # registers on_get_hello
+```
+
 ## Contributing
 
 ### Setting Up for Local Development

--- a/falcon_apispec/falcon_plugin.py
+++ b/falcon_apispec/falcon_plugin.py
@@ -12,34 +12,41 @@ class FalconPlugin(BasePlugin):
         self._app = app
 
     @staticmethod
-    def _generate_resource_uri_mapping(app, resource):
+    def _generate_resource_uri_mapping(app, resource, suffix):
         routes_to_check = copy.copy(app._router._roots)
 
         mapping = {}
         for route in routes_to_check:
-            if route.resource == resource:
-                uri = route.uri_template
-                mapping[uri] = {}
-
+            uri = route.uri_template
+            if route.resource == resource and ((suffix is not None and uri.endswith(suffix) is True) or suffix is None):
                 if route.method_map:
+                    print(route.method_map)
+                    methods = {}
                     for method_name, method_handler in route.method_map.items():
-                        if method_handler.__dict__.get("__module__") == "falcon.responders":
+                        if method_handler.__dict__.get("__module__") == "falcon.responders" or \
+                                (suffix is not None and not method_handler.__name__.lower().endswith(suffix)) or \
+                                (suffix is None and not method_handler.__name__.lower().endswith(method_name.lower())):
                             continue
-                        mapping[uri][method_name.lower()] = method_handler
+                        methods.update({method_name.lower(): method_handler})
+                    if methods:
+                        mapping[uri] = methods
 
             routes_to_check.extend(route.children)
         return mapping
 
-    def path_helper(self, operations, resource, base_path=None, **kwargs):
+    def path_helper(self, operations, resource, base_path=None, suffix=None, **kwargs):
         """Path helper that allows passing a Falcon resource instance."""
-        resource_uri_mapping = self._generate_resource_uri_mapping(self._app, resource)
-        print(resource_uri_mapping)
+        resource_uri_mapping = self._generate_resource_uri_mapping(self._app, resource, suffix)
 
         if not resource_uri_mapping:
             raise APISpecError("Could not find endpoint for resource {0}".format(resource))
 
         operations.update(yaml_utils.load_operations_from_docstring(resource.__doc__) or {})
-        path = resource_uri_mapping[resource]["uri"]
+
+        path = next(iter(resource_uri_mapping))
+        if len(resource_uri_mapping.keys()) > 1:
+            print(resource_uri_mapping)
+            raise APISpecError("More than one uri found")
 
         if base_path is not None:
             # make sure base_path accept either with or without leading slash
@@ -47,7 +54,7 @@ class FalconPlugin(BasePlugin):
             base_path = '/' + base_path.strip('/')
             path = re.sub(base_path, "", path, 1)
 
-        methods = resource_uri_mapping[resource]["methods"]
+        methods = resource_uri_mapping[path]
 
         for method_name, method_handler in methods.items():
             docstring_yaml = yaml_utils.load_yaml_from_docstring(method_handler.__doc__)

--- a/falcon_apispec/falcon_plugin.py
+++ b/falcon_apispec/falcon_plugin.py
@@ -28,8 +28,7 @@ class FalconPlugin(BasePlugin):
                                 (suffix is None and not method_handler.__name__.lower().endswith(method_name.lower())):
                             continue
                         methods.update({method_name.lower(): method_handler})
-                    if methods:
-                        mapping[uri] = methods
+                    mapping[uri] = methods
 
             routes_to_check.extend(route.children)
         return mapping

--- a/falcon_apispec/falcon_plugin.py
+++ b/falcon_apispec/falcon_plugin.py
@@ -18,8 +18,8 @@ class FalconPlugin(BasePlugin):
         mapping = {}
         for route in routes_to_check:
             uri = route.uri_template
-            # Filter by resource so we don't have to parse all routes + check for any existing & matching suffix
-            if route.resource == resource and ((suffix is not None and uri.endswith(suffix) is True) or suffix is None):
+            # Filter by resource so we don't have to parse all routes
+            if route.resource == resource:
                 mapping[uri] = {}
                 if route.method_map:
                     methods = {}

--- a/falcon_apispec/version.py
+++ b/falcon_apispec/version.py
@@ -1,1 +1,1 @@
-__version__ = "0.4.0"
+__version__ = "0.5.0alpha0"

--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,9 @@ setup(
         "apispec>=1.0",
         "falcon",
     ],
+    extras_require={
+        'dev': ['bump2version', 'tox', 'pytest', 'pytest-cov'],
+    },
     packages=find_packages(exclude=["tests", ]),
     test_suite='tests',
 

--- a/tests/falcon_test.py
+++ b/tests/falcon_test.py
@@ -2,6 +2,7 @@ import falcon
 import pytest
 from apispec import APISpec
 from apispec.exceptions import APISpecError
+from unittest.mock import MagicMock
 
 from falcon_apispec import FalconPlugin
 
@@ -112,6 +113,22 @@ class TestPathHelpers:
 
         hello_resource = HelloResource()
         app.add_route("/hi", hello_resource)
+        spec = spec_factory(app)
+        spec.path(resource=hello_resource)
+
+        assert spec._paths["/hi"]["x-extension"] == "global metadata"
+
+    def test_resource_no_methods(self, app, spec_factory):
+        class HelloResource:
+            """Greeting API.
+            ---
+            x-extension: global metadata
+            """
+
+        hello_resource = HelloResource()
+        magic_route = MagicMock(uri_template="/hi", resource=hello_resource, method_map=[])
+        app._router._roots.append(magic_route)
+
         spec = spec_factory(app)
         spec.path(resource=hello_resource)
 

--- a/tests/falcon_test.py
+++ b/tests/falcon_test.py
@@ -171,12 +171,12 @@ class TestPathHelpers:
             "responses": {"200": {"description": "said hi"}},
         }
 
-        app.add_route("/hello", suffixed_resource, suffix="hello")
+        app.add_route("/hi", suffixed_resource, suffix="hello")
 
         spec = spec_factory(app)
         spec.path(resource=suffixed_resource, suffix="hello")
 
-        assert spec._paths["/hello"]["get"] == expected
+        assert spec._paths["/hi"]["get"] == expected
 
     def test_path_ignore_suffix(self, app, spec_factory, suffixed_resource):
         expected = {
@@ -194,14 +194,14 @@ class TestPathHelpers:
     def test_path_suffix_all(self, app, spec_factory, suffixed_resource):
 
         app.add_route("/say", suffixed_resource)
-        app.add_route("/say/hello", suffixed_resource, suffix="hello")
+        app.add_route("/say/hi", suffixed_resource, suffix="hello")
 
         spec = spec_factory(app)
         spec.path(resource=suffixed_resource)
         spec.path(resource=suffixed_resource, suffix="hello")
 
         assert spec._paths["/say"]["get"]["description"] == "get something"
-        assert spec._paths["/say/hello"]["get"]["description"] == "get a greeting"
+        assert spec._paths["/say/hi"]["get"]["description"] == "get a greeting"
 
     def test_path_multiple_routes_same_resource(self, app, spec_factory):
         class HelloResource:

--- a/tox.ini
+++ b/tox.ini
@@ -1,2 +1,31 @@
+[tox]
+envlist =
+    check,
+    {py35, py37}
+
+[testenv]
+basepython =
+    py35: {env:TOXPYTHON:python3.5}
+    py37: {env:TOXPYTHON:python3.7}
+    {docs,clean,check,report}: {env:TOXPYTHON:python3}
+setenv =
+    PYTHONPATH={toxinidir}/tests
+    PYTHONUNBUFFERED=yes
+passenv =
+    *
+usedevelop = false
+deps =
+    pytest
+    pytest-cov
+commands =
+    pytest --cov --cov-report=term-missing -vv tests {posargs}
+
+[testenv:check]
+deps =
+    flake8
+skip_install = true
+commands =
+    flake8 falcon_apispec tests setup.py
+
 [flake8]
-max_line_length = 99
+max-line-length = 120


### PR DESCRIPTION
This is my take on this feature about supporting multiple routes/Falcon responders, some of which may be suffixed and use the same HTTP method type, e.g. on_get and on_get_hello.
The plugin is still immutable when parsing the uris, and the only constraint for the user who wants to expose the docstring for all the routes is to register the path for all the suffixes just like in [ebensonwwg's PR](https://github.com/alysivji/falcon-apispec/pull/23), but specifically passing this suffix. This does not look as "weird" as N+1 identical lines, and allows for selecting the suffix'ed methods to be registered.
As mentioned [here](https://github.com/alysivji/falcon-apispec/issues/28#issuecomment-779734640), APISpec registers one and only one path per spec.path() call, and a path cannot have multiple GETs or POSTs, so we're kind of doomed to call spec.path() multiple times.

As a bonus I also improved the tox configuration, and used bump2version to easily bump new releases.